### PR TITLE
Bumped broadway/broadway version to ~0.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=5.4.0",
         "behat/behat": "~3.0.4",
-        "broadway/broadway": "~0.5.0"
+        "broadway/broadway": "~0.6.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
I've bumped the version constraint to ~0.6.0 because that's where broadway is at the moment. If this is too restrictive I'm open to change it to something better (>=0.5.0 perhaps?).

What's the reason why this extension isn't published on packagist yet? Too alpha? 
